### PR TITLE
Alters missing inputs test to use file A rather than README.md

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -9,10 +9,11 @@ from tuttle.workflow_runner import ResourceError
 
 class TestWorkflow():
 
+    @isolate(['A'])
     def test_missing_inputs(self):
         """Test the list of missing inputs"""
         pp = ProjectParser()
-        project = """file://result <- file://file1, file://README.md"""
+        project = """file://result <- file://file1, file://A"""
         pp.set_project(project)
         workflow = pp.parse_project()
         missing = workflow.missing_inputs()


### PR DESCRIPTION
README.md might not be in the path depending on where you run the tests
 from e.g. PyCharm test runner won't find it unless base directory is
 added to the config. Also reduces number of files tests depend on.
