### PR TITLE
Shlex resource parse

### DIFF
--- a/tests/test_project_parser.py
+++ b/tests/test_project_parser.py
@@ -131,6 +131,17 @@ class TestProjectParser():
         print process._code
         assert process._code == "Some code\n"
 
+    def test_quoted_resources_can_contain_spaces(self):
+        pp = ProjectParser()
+        project = """'file:///result1 1'  file:///result2 <- file:///source1 'file:///source2 2'
+        Some code
+        """
+        pp.set_project(project)
+        pp.read_line()
+        process = pp.parse_section()
+        assert len(process._inputs) == 2
+        assert len(process._outputs) == 2
+
     def test_read_section_multiple_inputs_and_outputs(self):
         """Read a sections with multiple inputs and outputs"""
         pp = ProjectParser()

--- a/tuttle/project_parser.py
+++ b/tuttle/project_parser.py
@@ -5,7 +5,7 @@ from error import TuttleError
 from workflow_builder import WorkflowBuilder
 from workflow import Workflow
 from os.path import basename
-
+import shlex
 
 class ParseError(TuttleError):
     def __init__(self, message, filename, line):
@@ -170,16 +170,20 @@ class ProjectParser():
         if not process:
             raise InvalidProcessorError("Invalid processor : '{}' ".format(processor_name), self._filename, self._num_line)
         # Main separator is space, but comas are still accepted
-        inputs = self._line[arrow_pos + 2:mark_pos].replace(self.OLD_SEP, self.SPACE_SEP)
-        input_urls = inputs.split()
+        inputs = self._line[arrow_pos + 2:mark_pos]
+        input_urls = shlex.shlex(inputs, posix=True)
+        input_urls.whitespace = self.SPACE_SEP + self.OLD_SEP
+        input_urls.whitespace_split = True
         for input_url in input_urls:
             in_res = self.wb.get_or_build_resource(input_url.strip(), self.resources)
             if in_res is None:
                 raise InvalidResourceError("Invalid resource url : '{}' in inputs".format(input_url.strip()), self._filename, self._num_line)
             process.add_input(in_res)
         # Main separator is space, but comas are still accepted
-        outputs = self._line[:arrow_pos].replace(self.OLD_SEP, self.SPACE_SEP)
-        outputs_urls = outputs.split()
+        outputs = self._line[:arrow_pos]
+        outputs_urls = shlex.shlex(outputs, posix=True)
+        outputs_urls.whitespace = self.SPACE_SEP + self.OLD_SEP
+        outputs_urls.whitespace_split = True
         for output_url in outputs_urls:
             out_res = self.wb.get_or_build_resource(output_url.strip(), self.resources)
             if out_res is None:


### PR DESCRIPTION
Currently there's no way for a resource url to contain a space. These small change lex the resource list with shlex so you can have file://directory/"some file" or 'file://some directory/some file'.
