### PR TITLE
Extend workflow tests work with spaces and non-default python

### DIFF
--- a/tests/functional_tests/test_preprocessors.py
+++ b/tests/functional_tests/test_preprocessors.py
@@ -4,6 +4,7 @@ from os.path import isfile, dirname, abspath, join
 
 from os import path, environ
 from tests.functional_tests import isolate, run_tuttle_file
+import sys
 
 
 class TestPreprocessors:
@@ -70,11 +71,11 @@ class TestPreprocessors:
         """
         :return: A command line to call tuttle-extend-workflow even if tuttle has not been installed with pip
         """
-        py_cli = 'python'
+        py_cli = sys.executable
         #if environ.has_key('VIRTUAL_ENV'):
         #    py_cli = join(environ['VIRTUAL_ENV'], 'Scripts', 'python')
         extend = abspath(join(__file__, '..', '..', '..', 'bin', 'tuttle-extend-workflow'))
-        cmd_extend = "{} {}".format(py_cli, extend)
+        cmd_extend = '"{}" "{}"'.format(py_cli, extend)
         return cmd_extend
 
     @isolate(['A', 'b-produces-x.tuttle'])


### PR DESCRIPTION
Tests for extending workflow could previously fail when they called "python /some_directory/tuttle-extend-workflow" if running under a python other than the one in the path (especially if default python is 3). Changed to call the python we're running under.

Also quotes paths so it works with spaces in them.